### PR TITLE
Make data root directory dynamic via environment

### DIFF
--- a/code/iconclass.py
+++ b/code/iconclass.py
@@ -20,7 +20,7 @@ redis_c = redis.StrictRedis(
 
 __version__ = 1
 
-DATA_ROOT_DIR = '../data/'
+DATA_ROOT_DIR = os.environ.get('DATA_ROOT_DIR', '../data/')
 
 WITH_NAME_MATCH = re.compile(r'\((?!\.\.\.)[^+]+\)')
 BRACKETS = re.compile(r'\([\w ]+?\)')


### PR DESCRIPTION
When using the iconclass package via requirements.txt, the data directory might not always be in '../data'. Configuration via environment with a sane default solves this issue.

A possible addition / modification would be to prefix the environment variable with 'ICONCLASS_' to prevent conflicts with other data root directories.